### PR TITLE
Make rdiff-backup_testfiles.fix.sh idempotent.

### DIFF
--- a/rdiff-backup_testfiles.fix.sh
+++ b/rdiff-backup_testfiles.fix.sh
@@ -1,4 +1,4 @@
-find rdiff-backup_testfiles -user 1000 \! -type l -print0 | xargs -0 chown -v ${1:-$SUDO_UID}
-find rdiff-backup_testfiles -group 1000 \! -type l -print0 | xargs -0 chgrp -v ${2:-$SUDO_GID}
-find rdiff-backup_testfiles -user 1000 -type l -print0 | xargs -0 chown -vh ${1:-$SUDO_UID}
-find rdiff-backup_testfiles -group 1000 -type l -print0 | xargs -0 chgrp -vh ${2:-$SUDO_GID}
+find rdiff-backup_testfiles -user 1000 \! -type l -print0 | xargs -r -0 chown -v ${1:-$SUDO_UID}
+find rdiff-backup_testfiles -group 1000 \! -type l -print0 | xargs -r -0 chgrp -v ${2:-$SUDO_GID}
+find rdiff-backup_testfiles -user 1000 -type l -print0 | xargs -r -0 chown -vh ${1:-$SUDO_UID}
+find rdiff-backup_testfiles -group 1000 -type l -print0 | xargs -r -0 chgrp -vh ${2:-$SUDO_GID}


### PR DESCRIPTION
When running `rdiff-backup_testfiles.fix.sh` multiple times, `chown` and/or `chgrp` will eventually fail as they will be called without any argument. This change ensures that if `find` does not find any file, `xargs` does not run `chown`/`chgrp`.